### PR TITLE
perf: Add cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,20 +488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +827,12 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hashlink"
@@ -1408,11 +1400,11 @@ dependencies = [
  "async-stream",
  "clap",
  "config",
- "dashmap",
  "eyre",
  "futures",
  "lockfree-object-pool",
  "mimalloc",
+ "quick_cache",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1846,6 +1838,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.16.0",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1412,7 @@ dependencies = [
  "eyre",
  "futures",
  "lockfree-object-pool",
+ "mimalloc",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1459,6 +1470,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1398,7 @@ dependencies = [
  "async-stream",
  "clap",
  "config",
+ "dashmap",
  "eyre",
  "futures",
  "lockfree-object-pool",

--- a/load-balancer/Cargo.toml
+++ b/load-balancer/Cargo.toml
@@ -19,3 +19,4 @@ serde_json = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 dashmap = "6.1"
+mimalloc = { version = "0.1", features = ["v3"]}

--- a/load-balancer/Cargo.toml
+++ b/load-balancer/Cargo.toml
@@ -18,3 +18,4 @@ lockfree-object-pool = "0.1.6"
 serde_json = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+dashmap = "6.1"

--- a/load-balancer/Cargo.toml
+++ b/load-balancer/Cargo.toml
@@ -20,3 +20,6 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 dashmap = "6.1"
 mimalloc = { version = "0.1", features = ["v3"]}
+
+[profile.release]
+lto = true

--- a/load-balancer/Cargo.toml
+++ b/load-balancer/Cargo.toml
@@ -18,8 +18,8 @@ lockfree-object-pool = "0.1.6"
 serde_json = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-dashmap = "6.1"
-mimalloc = { version = "0.1", features = ["v3"]}
+mimalloc = { version = "0.1", features = ["v3"] }
+quick_cache = "0.6"
 
 [profile.release]
 lto = true

--- a/load-balancer/lb.example.yaml
+++ b/load-balancer/lb.example.yaml
@@ -26,3 +26,16 @@ listen_ip: 127.0.0.1
 listen_port: 1337
 # Time interval in seconds between session refreshes (default: 10)
 refresh_delay: 60
+# Path to the SQLite database to store all the sessions (default: null)
+# If null, the database will be kept on-memory, and if empty (""), "lb.sqlite" will be used.
+# The path supports the URI syntax: https://www.sqlite.org/uri.html
+sqlite_path: ./sessions.sqlite
+# Number of sessions to keep in the session-cluster mapping cache (default: 10000)
+# As a rule of thumb, a session entry in the cache should takes about a hundred bytes in memory.
+session_cache_size: 50000
+# Number of results to keep in the session-cluster mapping cache (default: 1000000)
+# As a rule of thumb, a result entry in the cache should takes about a hundred bytes in memory.
+result_cache_size: 2000
+# Number of tasks to keep in the session-cluster mapping cache (default: 1000000)
+# As a rule of thumb, a task entry in the cache should takes about a hundred bytes in memory.
+task_cache_size: 3000

--- a/load-balancer/src/cluster.rs
+++ b/load-balancer/src/cluster.rs
@@ -76,15 +76,9 @@ impl Cluster {
                         );
 
                         let endpoint = self.endpoint.clone();
-
-                        // Somehow, armonik::Client::with_config() is not Send
-                        // So we starting a blocking executor that blocks on the future to ensure it stays on the same thread
-                        tokio::task::spawn_blocking(move || {
-                            futures::executor::block_on(armonik::Client::with_config(endpoint))
-                        })
-                        .await
-                        .unwrap()
-                        .map(|client| reference.insert(client))
+                        armonik::Client::with_config(endpoint)
+                            .await
+                            .map(|client| reference.insert(client))
                     }
                 }
             })

--- a/load-balancer/src/main.rs
+++ b/load-balancer/src/main.rs
@@ -12,6 +12,7 @@ pub mod ref_guard;
 pub mod service;
 pub mod utils;
 
+#[cfg(not(miri))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/load-balancer/src/main.rs
+++ b/load-balancer/src/main.rs
@@ -12,6 +12,9 @@ pub mod ref_guard;
 pub mod service;
 pub mod utils;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ClusterConfig {
     /// Endpoint for sending requests

--- a/load-balancer/src/main.rs
+++ b/load-balancer/src/main.rs
@@ -67,6 +67,8 @@ pub struct LbConfig {
     pub listen_port: u16,
     #[serde(default)]
     pub refresh_delay: String,
+    #[serde(flatten)]
+    pub service_options: service::ServiceOptions,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Parser)]
@@ -170,6 +172,8 @@ async fn main() -> Result<(), eyre::Report> {
 
     let conf: LbConfig = conf.build()?.try_deserialize()?;
 
+    tracing::trace!("{conf:?}");
+
     let mut clusters = HashMap::with_capacity(conf.clusters.len());
 
     for (name, cluster_config) in conf.clusters {
@@ -182,7 +186,7 @@ async fn main() -> Result<(), eyre::Report> {
         );
     }
 
-    let service = Arc::new(service::Service::new(clusters).await);
+    let service = Arc::new(service::Service::new(clusters, conf.service_options).await);
     let refresh_delay = std::time::Duration::from_secs_f64(conf.refresh_delay.parse()?);
 
     let router = tonic::transport::Server::builder()

--- a/load-balancer/src/service/sessions.rs
+++ b/load-balancer/src/service/sessions.rs
@@ -308,7 +308,7 @@ impl SessionsService for Service {
 
         let mut err = None;
 
-        for (cluster_name, cluster) in self.clusters.iter().cycle().skip(i % n).take(n) {
+        for cluster in self.clusters.values().cycle().skip(i % n).take(n) {
             match cluster.client().await {
                 Ok(mut client) => {
                     let span = client.span();
@@ -323,7 +323,7 @@ impl SessionsService for Service {
                             self.add_sessions(
                                 vec![Session {
                                     session_id: response.session_id.clone(),
-                                    cluster: cluster_name.clone(),
+                                    cluster: cluster.name.clone(),
                                     status: armonik::SessionStatus::Running as i32 as u8,
                                     client_submission: true,
                                     worker_submission: true,
@@ -337,7 +337,7 @@ impl SessionsService for Service {
                                     duration: None,
                                 }
                                 .into()],
-                                cluster_name.clone(),
+                                cluster.clone(),
                             )
                             .await?;
                             return Ok(response);


### PR DESCRIPTION
When fetching the cluster from the session, the LB would query SQLite. Instead, we add a cache to avoid querying the DB every time. The task and result mappings are also changed to use the cache instead of an ever growing hashmap.
The cache evicts entries if there is too many entries.