### PR TITLE
feat: Add fallback cluster

### DIFF
--- a/load-balancer/lb.example.yaml
+++ b/load-balancer/lb.example.yaml
@@ -23,6 +23,8 @@ clusters:
     # Whether a connection can process multiple requests simultaneously (default: false)
     # If the upstream cluster requests the connection closure regularly (like nginx), it is recommended to keep it disabled.
     multiplex: true
+    # Set the cluster as a fallback if no cluster could be matched
+    fallback: false
 
   # configuration for the cluster called "local"
   local:

--- a/load-balancer/src/cluster.rs
+++ b/load-balancer/src/cluster.rs
@@ -20,9 +20,12 @@ pub struct ClusterConfig<C = armonik::ClientConfig> {
     /// Number of requests sent on a connection before it is recreated
     #[serde(default)]
     pub requests_per_connection: Option<usize>,
-    /// Whether a connection can process mutliple requests simultaneously
+    /// Whether a connection can process multiple requests simultaneously
     #[serde(default)]
     pub multiplex: bool,
+    /// Set the cluster as a fallback if no cluster could be matched
+    #[serde(default)]
+    pub fallback: bool,
 }
 
 impl<C> ClusterConfig<C> {
@@ -35,6 +38,7 @@ impl<C> ClusterConfig<C> {
             pool_size: self.pool_size,
             requests_per_connection: self.requests_per_connection,
             multiplex: self.multiplex,
+            fallback: self.fallback,
         })
     }
 }

--- a/load-balancer/src/service/mod.rs
+++ b/load-balancer/src/service/mod.rs
@@ -275,6 +275,17 @@ impl Service {
         &self,
         session_ids: &[&str],
     ) -> Result<HashMap<Arc<Cluster>, Vec<String>>, Status> {
+        if self.clusters.len() == 1 && self.fallbacks.len() == 1 {
+            let cluster = self.fallbacks.iter().next().unwrap().clone();
+
+            return Ok([(
+                cluster,
+                session_ids.iter().copied().map(String::from).collect(),
+            )]
+            .into_iter()
+            .collect());
+        }
+
         let mut missing_ids = HashSet::new();
         let mut mapping = HashMap::<Arc<Cluster>, Vec<String>>::new();
 
@@ -446,6 +457,17 @@ impl Service {
         &self,
         result_ids: &[&str],
     ) -> Result<HashMap<Arc<Cluster>, Vec<String>>, Status> {
+        if self.clusters.len() == 1 && self.fallbacks.len() == 1 {
+            let cluster = self.fallbacks.iter().next().unwrap().clone();
+
+            return Ok([(
+                cluster,
+                result_ids.iter().copied().map(String::from).collect(),
+            )]
+            .into_iter()
+            .collect());
+        }
+
         let mut missing_ids = HashSet::new();
         let mut mapping = HashMap::<Arc<Cluster>, Vec<String>>::new();
 
@@ -569,6 +591,17 @@ impl Service {
         &self,
         task_ids: &[&str],
     ) -> Result<HashMap<Arc<Cluster>, Vec<String>>, Status> {
+        if self.clusters.len() == 1 && self.fallbacks.len() == 1 {
+            let cluster = self.fallbacks.iter().next().unwrap().clone();
+
+            return Ok([(
+                cluster,
+                task_ids.iter().copied().map(String::from).collect(),
+            )]
+            .into_iter()
+            .collect());
+        }
+
         let mut missing_ids = HashSet::new();
         let mut mapping = HashMap::<Arc<Cluster>, Vec<String>>::new();
 

--- a/load-balancer/src/service/mod.rs
+++ b/load-balancer/src/service/mod.rs
@@ -54,6 +54,7 @@ impl Default for ServiceOptions {
 
 pub struct Service {
     clusters: HashMap<String, Arc<Cluster>>,
+    fallbacks: HashSet<Arc<Cluster>>,
     db: DB,
     mapping_session: Cache<String, Arc<Cluster>>,
     mapping_result: Cache<String, Arc<Cluster>>,
@@ -137,6 +138,7 @@ impl Deref for DB {
 impl Service {
     pub async fn new(
         clusters: impl IntoIterator<Item = (String, Cluster)>,
+        fallbacks: impl IntoIterator<Item = String>,
         options: ServiceOptions,
     ) -> Self {
         let sqlite_path = options.sqlite_path;
@@ -172,11 +174,17 @@ impl Service {
         )
         .await
         .unwrap();
+        let clusters = clusters
+            .into_iter()
+            .map(|(name, cluster)| (name, Arc::new(cluster)))
+            .collect::<HashMap<_, _>>();
+        let fallbacks = fallbacks
+            .into_iter()
+            .map(|cluster_name| clusters[&cluster_name].clone())
+            .collect();
         Self {
-            clusters: clusters
-                .into_iter()
-                .map(|(name, cluster)| (name, Arc::new(cluster)))
-                .collect(),
+            clusters,
+            fallbacks,
             db,
             mapping_session: Cache::new(options.session_cache_size),
             mapping_result: Cache::new(options.result_cache_size),
@@ -392,16 +400,32 @@ impl Service {
             }
 
             if !missing_ids.is_empty() {
-                let mut message = String::new();
-                let mut sep = "";
-                for (cluster, error) in errors {
-                    let cluster_name = &cluster.name;
-                    message.push_str(&format!(
-                        "{sep}Error while fetching sessions from cluster {cluster_name}: {error}"
-                    ));
-                    sep = "\n";
+                if self.fallbacks.is_empty() {
+                    let mut message = String::new();
+                    let mut sep = "";
+                    for (cluster, error) in errors {
+                        let cluster_name = &cluster.name;
+                        message.push_str(&format!(
+                            "{sep}Error while fetching sessions from cluster {cluster_name}: {error}"
+                        ));
+                        sep = "\n";
+                    }
+                    return Err(Status::unavailable(message));
                 }
-                return Err(Status::unavailable(message));
+
+                let cluster = self
+                    .fallbacks
+                    .iter()
+                    .nth(
+                        self.counter.load(std::sync::atomic::Ordering::Relaxed)
+                            % self.fallbacks.len(),
+                    )
+                    .unwrap()
+                    .clone();
+                let entry = mapping.entry(cluster.clone()).or_default();
+                for session_id in missing_ids {
+                    entry.push(session_id);
+                }
             }
         }
 
@@ -499,16 +523,32 @@ impl Service {
             }
 
             if !missing_ids.is_empty() {
-                let mut message = String::new();
-                let mut sep = "";
-                for (cluster, error) in errors {
-                    let cluster_name = &cluster.name;
-                    message.push_str(&format!(
-                        "{sep}Error while fetching results from cluster {cluster_name}: {error}"
-                    ));
-                    sep = "\n";
+                if self.fallbacks.is_empty() {
+                    let mut message = String::new();
+                    let mut sep = "";
+                    for (cluster, error) in errors {
+                        let cluster_name = &cluster.name;
+                        message.push_str(&format!(
+                            "{sep}Error while fetching results from cluster {cluster_name}: {error}"
+                        ));
+                        sep = "\n";
+                    }
+                    return Err(Status::unavailable(message));
                 }
-                return Err(Status::unavailable(message));
+
+                let cluster = self
+                    .fallbacks
+                    .iter()
+                    .nth(
+                        self.counter.load(std::sync::atomic::Ordering::Relaxed)
+                            % self.fallbacks.len(),
+                    )
+                    .unwrap()
+                    .clone();
+                let entry = mapping.entry(cluster.clone()).or_default();
+                for result_id in missing_ids {
+                    entry.push(String::from(result_id));
+                }
             }
         }
 
@@ -612,16 +652,32 @@ impl Service {
             }
 
             if !missing_ids.is_empty() {
-                let mut message = String::new();
-                let mut sep = "";
-                for (cluster, error) in errors {
-                    let cluster_name = &cluster.name;
-                    message.push_str(&format!(
-                        "{sep}Error while fetching tasks from cluster {cluster_name}: {error}"
-                    ));
-                    sep = "\n";
+                if self.fallbacks.is_empty() {
+                    let mut message = String::new();
+                    let mut sep = "";
+                    for (cluster, error) in errors {
+                        let cluster_name = &cluster.name;
+                        message.push_str(&format!(
+                            "{sep}Error while fetching tasks from cluster {cluster_name}: {error}"
+                        ));
+                        sep = "\n";
+                    }
+                    return Err(Status::unavailable(message));
                 }
-                return Err(Status::unavailable(message));
+
+                let cluster = self
+                    .fallbacks
+                    .iter()
+                    .nth(
+                        self.counter.load(std::sync::atomic::Ordering::Relaxed)
+                            % self.fallbacks.len(),
+                    )
+                    .unwrap()
+                    .clone();
+                let entry = mapping.entry(cluster.clone()).or_default();
+                for task_id in missing_ids {
+                    entry.push(String::from(task_id));
+                }
             }
         }
 


### PR DESCRIPTION
Add an option on clusters to have fallbacks that can be called whenever there is no single cluster that can handle the request.