### PR TITLE
feat: Forward headers

### DIFF
--- a/load-balancer/README.md
+++ b/load-balancer/README.md
@@ -67,6 +67,17 @@ docker run --rm \
   dockerhubaneo/armonik_load_balancer
 ```
 
+## Authentication
+
+The Load Balancer does not perform any form of authorization/authentication.
+It expects the authentication to be handled by the nginx that is in front of it.
+You can find an example of nginx configuration in the [ArmoniK.Infra](https://github.com/aneoconsulting/ArmoniK.Infra/blob/main/armonik/ingress-configmap.tf) repository.
+
+The Load Balancer can propagates user identity to the upstream cluster by forwarding authentication headers from nginx.
+You must then configure the nginx *behind* the Load Balancer to keep these headers if the client certificate is the one used by the Load Balancer.
+You can change the list of forward headers using the `forward_headers` cluster configuration.
+By default it forwards the following headers: `X-Certificate-Client-CN`, `X-Certificate-Client-Fingerprint`
+
 # Logs
 
 By default, the load balancer logs only errors and warnings to stdout.

--- a/load-balancer/lb.example.yaml
+++ b/load-balancer/lb.example.yaml
@@ -25,6 +25,9 @@ clusters:
     multiplex: true
     # Set the cluster as a fallback if no cluster could be matched
     fallback: false
+    # Headers to forward to the cluster if present
+    # (default: ["X-Certificate-Client-CN", "X-Certificate-Client-Fingerprint"]
+    forward_headers: ["X-Certificate-Client-CN"]
 
   # configuration for the cluster called "local"
   local:

--- a/load-balancer/src/cluster.rs
+++ b/load-balancer/src/cluster.rs
@@ -118,6 +118,7 @@ impl Cluster {
                     String::from("X-Certificate-Client-Fingerprint"),
                 ])
                 .into_iter()
+                .map(|header| header.to_lowercase())
                 .collect(),
         }
     }
@@ -144,7 +145,7 @@ impl Cluster {
                 .headers()
                 .iter()
                 .filter_map(|(key, value)| {
-                    if self.forward_headers.contains(key.as_str()) {
+                    if self.forward_headers.contains(&key.as_str().to_lowercase()) {
                         Some((key.clone(), value.clone()))
                     } else {
                         None

--- a/load-balancer/src/service/auth.rs
+++ b/load-balancer/src/service/auth.rs
@@ -15,13 +15,16 @@ impl AuthService for Service {
     async fn current_user(
         self: Arc<Self>,
         _request: auth::current_user::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<auth::current_user::Response, tonic::Status> {
         let mut users = self
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .auth()

--- a/load-balancer/src/service/events.rs
+++ b/load-balancer/src/service/events.rs
@@ -14,7 +14,7 @@ impl EventsService for Service {
     async fn subscribe(
         self: Arc<Self>,
         request: events::subscribe::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> Result<
         impl tonic::codegen::tokio_stream::Stream<
                 Item = Result<events::subscribe::Response, tonic::Status>,
@@ -37,7 +37,7 @@ impl EventsService for Service {
         let span = tracing::Span::current();
         let stream = async_stream::stream! {
             let mut client = try_rpc!(map cluster
-                .client()
+                .client(&context)
                 .instrument(span)
                 .await)?;
             let span = client.span();

--- a/load-balancer/src/service/health_check.rs
+++ b/load-balancer/src/service/health_check.rs
@@ -15,7 +15,7 @@ impl HealthChecksService for Service {
     async fn check(
         self: Arc<Self>,
         _request: health_checks::check::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<health_checks::check::Response, tonic::Status> {
         let mut services = HashMap::<String, (health_checks::Status, String)>::new();
 
@@ -23,7 +23,10 @@ impl HealthChecksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .health_checks()

--- a/load-balancer/src/service/mod.rs
+++ b/load-balancer/src/service/mod.rs
@@ -366,7 +366,7 @@ impl Service {
                 .clusters
                 .values()
                 .map(|cluster| async {
-                    let mut client = match cluster.client().await {
+                    let mut client = match cluster.client(&Default::default()).await {
                         Ok(client) => client,
                         Err(err) => return (cluster.clone(), Err(IntoStatus::into_status(err))),
                     };
@@ -506,7 +506,7 @@ impl Service {
                 .clusters
                 .values()
                 .map(|cluster| async {
-                    let mut client = match cluster.client().await {
+                    let mut client = match cluster.client(&Default::default()).await {
                         Ok(client) => client,
                         Err(err) => return (cluster.clone(), Err(IntoStatus::into_status(err))),
                     };
@@ -640,7 +640,7 @@ impl Service {
                 .clusters
                 .values()
                 .map(|cluster| async {
-                    let mut client = match cluster.client().await {
+                    let mut client = match cluster.client(&Default::default()).await {
                         Ok(client) => client,
                         Err(err) => return (cluster.clone(), Err(IntoStatus::into_status(err))),
                     };
@@ -730,7 +730,7 @@ impl Service {
     pub async fn update_sessions(&self) -> Result<(), Status> {
         let streams = self.clusters.values().map(|cluster| {
             Box::pin(async_stream::stream! {
-                let mut client = match cluster.client().await.map_err(IntoStatus::into_status) {
+                let mut client = match cluster.client(&Default::default()).await.map_err(IntoStatus::into_status) {
                     Ok(client) => client,
                     Err(err) => {
                         yield (cluster.clone(), Err(err));

--- a/load-balancer/src/service/sessions.rs
+++ b/load-balancer/src/service/sessions.rs
@@ -282,23 +282,23 @@ impl SessionsService for Service {
     async fn get(
         self: Arc<Self>,
         request: sessions::get::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::get::Response, tonic::Status> {
-        impl_unary!(self.sessions, request, session)
+        impl_unary!(self.sessions, request, context, session)
     }
 
     async fn cancel(
         self: Arc<Self>,
         request: sessions::cancel::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::cancel::Response, tonic::Status> {
-        impl_unary!(self.sessions, request, session)
+        impl_unary!(self.sessions, request, context, session)
     }
 
     async fn create(
         self: Arc<Self>,
         request: sessions::create::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::create::Response, tonic::Status> {
         let n = self.clusters.len();
         let i = self
@@ -308,7 +308,7 @@ impl SessionsService for Service {
         let mut err = None;
 
         for cluster in self.clusters.values().cycle().skip(i % n).take(n) {
-            match cluster.client().await {
+            match cluster.client(&context).await {
                 Ok(mut client) => {
                     let span = client.span();
                     let response = client
@@ -357,43 +357,43 @@ impl SessionsService for Service {
     async fn pause(
         self: Arc<Self>,
         request: sessions::pause::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::pause::Response, tonic::Status> {
-        impl_unary!(self.sessions, request, session)
+        impl_unary!(self.sessions, request, context, session)
     }
 
     async fn resume(
         self: Arc<Self>,
         request: sessions::resume::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::resume::Response, tonic::Status> {
-        impl_unary!(self.sessions, request, session)
+        impl_unary!(self.sessions, request, context, session)
     }
 
     async fn close(
         self: Arc<Self>,
         request: sessions::close::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::close::Response, tonic::Status> {
-        impl_unary!(self.sessions, request, session)
+        impl_unary!(self.sessions, request, context, session)
     }
 
     async fn purge(
         self: Arc<Self>,
         request: sessions::purge::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::purge::Response, tonic::Status> {
-        impl_unary!(self.sessions, request, session)
+        impl_unary!(self.sessions, request, context, session)
     }
 
     async fn delete(
         self: Arc<Self>,
         request: sessions::delete::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::delete::Response, tonic::Status> {
         let service = self.clone();
         let session_id = request.session_id.clone();
-        let response = impl_unary!(service.sessions, request, session)?;
+        let response = impl_unary!(service.sessions, request, context, session)?;
 
         // If delete is successful, remove the session from the list
         try_rpc!(try self.db
@@ -410,9 +410,9 @@ impl SessionsService for Service {
     async fn stop_submission(
         self: Arc<Self>,
         request: sessions::stop_submission::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<sessions::stop_submission::Response, tonic::Status> {
-        impl_unary!(self.sessions, request, session)
+        impl_unary!(self.sessions, request, context, session)
     }
 }
 

--- a/load-balancer/src/service/submitter.rs
+++ b/load-balancer/src/service/submitter.rs
@@ -17,7 +17,7 @@ impl SubmitterService for Service {
     async fn get_service_configuration(
         self: Arc<Self>,
         _request: submitter::get_service_configuration::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::get_service_configuration::Response, tonic::Status> {
         tracing::warn!("SubmitterService::GetServiceConfiguration is deprecated, please use ResultsService::GetServiceConfiguration instead");
 
@@ -35,7 +35,10 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .submitter()
@@ -80,7 +83,7 @@ impl SubmitterService for Service {
     async fn create_session(
         self: Arc<Self>,
         request: submitter::create_session::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::create_session::Response, tonic::Status> {
         tracing::warn!("SubmitterService::CreateSession is deprecated, please use SessionsService::CreateSession instead");
 
@@ -92,7 +95,7 @@ impl SubmitterService for Service {
         let mut err = None;
 
         for (_, cluster) in self.clusters.iter().cycle().skip(i % n).take(n) {
-            match cluster.client().await {
+            match cluster.client(&context).await {
                 Ok(mut client) => {
                     let span = client.span();
                     let response = client
@@ -119,17 +122,17 @@ impl SubmitterService for Service {
     async fn cancel_session(
         self: Arc<Self>,
         request: submitter::cancel_session::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::cancel_session::Response, tonic::Status> {
         tracing::warn!("SubmitterService::CancelSession is deprecated, please use SessionsService::CancelSession instead");
 
-        impl_unary!(self.submitter, request, session)
+        impl_unary!(self.submitter, request, context, session)
     }
 
     async fn list_tasks(
         self: Arc<Self>,
         request: submitter::list_tasks::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::list_tasks::Response, tonic::Status> {
         tracing::warn!(
             "SubmitterService::ListTasks is deprecated, please use TasksService::ListTasks instead"
@@ -141,7 +144,10 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .submitter()
@@ -177,7 +183,7 @@ impl SubmitterService for Service {
     async fn list_sessions(
         self: Arc<Self>,
         request: submitter::list_sessions::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::list_sessions::Response, tonic::Status> {
         tracing::warn!("SubmitterService::ListSessions is deprecated, please use SessionsService::ListSessions instead");
 
@@ -187,7 +193,10 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .submitter()
@@ -223,7 +232,7 @@ impl SubmitterService for Service {
     async fn count_tasks(
         self: Arc<Self>,
         request: submitter::count_tasks::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::count_tasks::Response, tonic::Status> {
         tracing::warn!(
             "SubmitterService::CountTasks is deprecated, please use TasksService::CountTasksByStatus instead"
@@ -235,7 +244,10 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .submitter()
@@ -275,21 +287,21 @@ impl SubmitterService for Service {
     async fn try_get_task_output(
         self: Arc<Self>,
         request: submitter::try_get_task_output::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::try_get_task_output::Response, tonic::Status> {
         tracing::warn!(
             "SubmitterService::TryGetTaskOutput is deprecated, please use TasksService::GetTask instead"
         );
-        crate::utils::impl_unary!(self.submitter, request, session)
+        crate::utils::impl_unary!(self.submitter, request, context, session)
     }
 
     async fn wait_for_availability(
         self: Arc<Self>,
         request: submitter::wait_for_availability::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::wait_for_availability::Response, tonic::Status> {
         tracing::warn!("SubmitterService::WaitForAvailability is deprecated, please use EventsService::GetEvents instead");
-        crate::utils::impl_unary!(self.submitter, request, session)
+        crate::utils::impl_unary!(self.submitter, request, context, session)
     }
 
     async fn wait_for_completion(
@@ -304,7 +316,10 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .submitter()
@@ -368,7 +383,7 @@ impl SubmitterService for Service {
     async fn cancel_tasks(
         self: Arc<Self>,
         request: submitter::cancel_tasks::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::cancel_tasks::Response, tonic::Status> {
         tracing::warn!(
             "SubmitterService::CancelTasks is deprecated, please use TasksService::CancelTasks instead"
@@ -378,7 +393,10 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .submitter()
@@ -416,7 +434,7 @@ impl SubmitterService for Service {
     async fn task_status(
         self: Arc<Self>,
         request: submitter::task_status::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::task_status::Response, tonic::Status> {
         tracing::warn!(
             "SubmitterService::TaskStatus is deprecated, please use TasksService::ListTasks instead"
@@ -425,7 +443,7 @@ impl SubmitterService for Service {
         let mut error = None;
 
         for cluster in self.clusters.values() {
-            let mut client = match cluster.client().await {
+            let mut client = match cluster.client(&context).await {
                 Ok(client) => client,
                 Err(err) => {
                     tracing::warn!("Error while counting tasks, count could be partial: {err}");
@@ -459,16 +477,16 @@ impl SubmitterService for Service {
     async fn result_status(
         self: Arc<Self>,
         request: submitter::result_status::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<submitter::result_status::Response, tonic::Status> {
         tracing::warn!("SubmitterService::ResultStatus is deprecated, please use ResultsService::ListResults instead");
-        crate::utils::impl_unary!(self.submitter, request, session)
+        crate::utils::impl_unary!(self.submitter, request, context, session)
     }
 
     async fn try_get_result(
         self: Arc<Self>,
         request: submitter::try_get_result::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> Result<
         impl tonic::codegen::tokio_stream::Stream<
                 Item = Result<submitter::try_get_result::Response, tonic::Status>,
@@ -491,7 +509,7 @@ impl SubmitterService for Service {
         let span = tracing::Span::current();
         Ok(async_stream::try_stream! {
             let mut client = try_rpc!(map cluster
-                .client()
+                .client(&context)
                 .instrument(span)
                 .await)?;
             let span = client.span();
@@ -510,12 +528,12 @@ impl SubmitterService for Service {
     async fn create_small_tasks(
         self: Arc<Self>,
         request: submitter::create_tasks::SmallRequest,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> Result<submitter::create_tasks::Response, tonic::Status> {
         tracing::warn!(
             "SubmitterService::CreateSmallTasks is deprecated, please use a combination of ResultsService::CreateResults and TasksService::SubmitTasks instead"
         );
-        crate::utils::impl_unary!(self.submitter, request, session)
+        crate::utils::impl_unary!(self.submitter, request, context, session)
     }
 
     async fn create_large_tasks(
@@ -524,7 +542,7 @@ impl SubmitterService for Service {
                 Item = Result<submitter::create_tasks::LargeRequest, tonic::Status>,
             > + Send
             + 'static,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> Result<submitter::create_tasks::Response, tonic::Status> {
         tracing::warn!(
             "SubmitterService::CreateLargeTasks is deprecated, please use a combination of ResultsService::CreateResults and TasksService::SubmitTasks instead"
@@ -570,7 +588,7 @@ impl SubmitterService for Service {
                 };
 
                 let mut client = try_rpc!(try cluster
-                    .client()
+                    .client(&context)
                     .await);
                 let span = client.span();
                 let mut submitter_client = client.submitter();

--- a/load-balancer/src/service/versions.rs
+++ b/load-balancer/src/service/versions.rs
@@ -15,13 +15,16 @@ impl VersionsService for Service {
     async fn list(
         self: Arc<Self>,
         _request: versions::list::Request,
-        _context: RequestContext,
+        context: RequestContext,
     ) -> std::result::Result<versions::list::Response, tonic::Status> {
         let mut cluster_versions = self
             .clusters
             .values()
             .map(|cluster| async {
-                let mut client = cluster.client().await.map_err(IntoStatus::into_status)?;
+                let mut client = cluster
+                    .client(&context)
+                    .await
+                    .map_err(IntoStatus::into_status)?;
                 let span = client.span();
                 client
                     .versions()

--- a/load-balancer/src/utils.rs
+++ b/load-balancer/src/utils.rs
@@ -3,17 +3,17 @@ use armonik::reexports::tonic::Status;
 use futures::{stream::futures_unordered, Stream, StreamExt};
 
 macro_rules! impl_unary {
-    ($self:ident.$service:ident, $request:ident, session) => {
-        crate::utils::impl_unary!($self.$service, $request, {get_cluster_from_session, session_id, "Session {} was not found"})
+    ($self:ident.$service:ident, $request:ident, $context:ident, session) => {
+        crate::utils::impl_unary!($self.$service, $request, $context, {get_cluster_from_session, session_id, "Session {} was not found"})
     };
-    ($self:ident.$service:ident, $request:ident, result) => {
-        crate::utils::impl_unary!($self.$service, $request, {get_cluster_from_result, result_id, "Result {} was not found"})
+    ($self:ident.$service:ident, $request:ident, $context:ident, result) => {
+        crate::utils::impl_unary!($self.$service, $request, $context, {get_cluster_from_result, result_id, "Result {} was not found"})
     };
-    ($self:ident.$service:ident, $request:ident, task) => {
-        crate::utils::impl_unary!($self.$service, $request, {get_cluster_from_task, task_id, "Task {} was not found"})
+    ($self:ident.$service:ident, $request:ident, $context:ident, task) => {
+        crate::utils::impl_unary!($self.$service, $request, $context, {get_cluster_from_task, task_id, "Task {} was not found"})
     };
 
-    ($self:ident.$service:ident, $request:ident, {$get_cluster:ident, $id:ident, $msg:literal}) => {
+    ($self:ident.$service:ident, $request:ident, $context:ident, {$get_cluster:ident, $id:ident, $msg:literal}) => {
         {
             let Some(cluster) = crate::utils::try_rpc!(try $self.$get_cluster(&$request.$id).await) else {
                 crate::utils::try_rpc!(bail tonic::Status::not_found(format!(
@@ -23,7 +23,7 @@ macro_rules! impl_unary {
             };
 
             let mut client = crate::utils::try_rpc!(try cluster
-                .client()
+                .client(&$context)
                 .await);
             let span = client.span();
             crate::utils::try_rpc!(map client.$service()


### PR DESCRIPTION
# Motivation

The Load Balancer does not support authentication / authorization in any way or form.

# Description

This PR adds configuration to forward some specific headers of the user request to the upstream clusters.
This enables the user information from nginx in front of the LB to be forwarded to the upstream cluster to let it check the authorization of the user.