### PR TITLE
feat: gRPC-Web support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "serde_json",
  "thread_local",
  "tokio",
+ "tonic-web",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2725,6 +2726,24 @@ dependencies = [
  "syn",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75214f6b6bd28c19aa752ac09fdf0eea546095670906c21fe3940e180a4c43f2"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project",
+ "tokio-stream",
+ "tonic",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/load-balancer/Cargo.toml
+++ b/load-balancer/Cargo.toml
@@ -25,6 +25,7 @@ quick_cache = "0.6"
 rayon = "1.11"
 thread_local = "1.1"
 crossbeam-deque = "0.8"
+tonic-web = "0.14"
 
 [profile.release]
 lto = true

--- a/load-balancer/src/main.rs
+++ b/load-balancer/src/main.rs
@@ -177,8 +177,10 @@ async fn main() -> Result<(), eyre::Report> {
     let refresh_delay = std::time::Duration::from_secs_f64(conf.refresh_delay.parse()?);
 
     let router = tonic::transport::Server::builder()
+        .accept_http1(true)
         .trace_fn(|r| tracing::info_span!("gRPC", "path" = r.uri().path()))
         .http2_max_pending_accept_reset_streams(Some(65536))
+        .layer(tonic_web::GrpcWebLayer::new())
         .add_service(
             armonik::api::v3::applications::applications_server::ApplicationsServer::from_arc(
                 service.clone(),


### PR DESCRIPTION
# Motivation

The GUI needs the server to support gRPC-Web even if there is an nginx server in front of the load balancer, as nginx does not translate gRPC-Web to standard gRPC.

# Description

Add support for gRPC-Web to the tonic server.

# Test

Infrastructure has been deployed with the Load Balancer between the nginx server and the control-plane.
Both gRPC native clients and GUI work with this patch.