### PR TITLE
feat(load-balancer): skip unavailable clusters using atomic availability flag

### DIFF
--- a/load-balancer/src/cluster.rs
+++ b/load-balancer/src/cluster.rs
@@ -3,7 +3,7 @@ use std::{
     hash::Hash,
     num::NonZeroUsize,
     ops::{Deref, DerefMut},
-    sync::atomic::AtomicBool,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use armonik::{
@@ -68,7 +68,11 @@ pub struct Cluster {
     pub multiplex: bool,
     pub forward_headers: HashSet<String>,
     pub extra_headers: HashMap<String, String>,
-    pub available: AtomicBool,
+    // Updated only by `update_sessions` (the periodic background sync). Live RPC
+    // failures in service handlers do not write this flag, so a cluster that passes
+    // the sync but then starts failing requests will appear available until the
+    // next sync cycle.
+    available: AtomicBool,
 }
 
 impl std::fmt::Debug for Cluster {
@@ -133,6 +137,18 @@ impl Cluster {
                 .into_iter()
                 .collect(),
             available: AtomicBool::new(true),
+        }
+    }
+
+    pub fn is_available(&self) -> bool {
+        // Relaxed: this is a best-effort hint; no cross-thread data dependency on the value.
+        self.available.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn set_available(&self, value: bool) {
+        let old = self.available.swap(value, Ordering::Relaxed);
+        if old != value {
+            tracing::info!(name = self.name, available = value, "Cluster availability changed");
         }
     }
 

--- a/load-balancer/src/cluster.rs
+++ b/load-balancer/src/cluster.rs
@@ -148,7 +148,11 @@ impl Cluster {
     pub(crate) fn set_available(&self, value: bool) {
         let old = self.available.swap(value, Ordering::Relaxed);
         if old != value {
-            tracing::info!(name = self.name, available = value, "Cluster availability changed");
+            tracing::info!(
+                name = self.name,
+                available = value,
+                "Cluster availability changed"
+            );
         }
     }
 

--- a/load-balancer/src/cluster.rs
+++ b/load-balancer/src/cluster.rs
@@ -3,6 +3,7 @@ use std::{
     hash::Hash,
     num::NonZeroUsize,
     ops::{Deref, DerefMut},
+    sync::atomic::AtomicBool,
 };
 
 use armonik::{
@@ -67,6 +68,7 @@ pub struct Cluster {
     pub multiplex: bool,
     pub forward_headers: HashSet<String>,
     pub extra_headers: HashMap<String, String>,
+    pub available: AtomicBool,
 }
 
 impl std::fmt::Debug for Cluster {
@@ -130,6 +132,7 @@ impl Cluster {
                 .unwrap_or_default()
                 .into_iter()
                 .collect(),
+            available: AtomicBool::new(true),
         }
     }
 

--- a/load-balancer/src/service/applications.rs
+++ b/load-balancer/src/service/applications.rs
@@ -30,6 +30,10 @@ impl ApplicationsService for Service {
             let context =
                 RequestContext::new(context.headers().clone(), context.extensions().clone());
             Box::pin(async_stream::stream! {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!("Skipping cluster {} because it is marked as unavailable", cluster.name);
+                    Err(tonic::Status::unavailable("Cluster is unavailable"))?;
+                }
                 let mut client = cluster
                     .client(&context)
                     .await

--- a/load-balancer/src/service/applications.rs
+++ b/load-balancer/src/service/applications.rs
@@ -30,9 +30,9 @@ impl ApplicationsService for Service {
             let context =
                 RequestContext::new(context.headers().clone(), context.extensions().clone());
             Box::pin(async_stream::stream! {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!("Skipping cluster {} because it is marked as unavailable", cluster.name);
-                    Err(tonic::Status::unavailable("Cluster is unavailable"))?;
+                    Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)))?;
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/auth.rs
+++ b/load-balancer/src/service/auth.rs
@@ -26,7 +26,10 @@ impl AuthService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)))?;
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )))?;
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/auth.rs
+++ b/load-balancer/src/service/auth.rs
@@ -21,12 +21,12 @@ impl AuthService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)))?;
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/auth.rs
+++ b/load-balancer/src/service/auth.rs
@@ -26,7 +26,7 @@ impl AuthService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!(
+                    Err(tonic::Status::unavailable(format!(
                         "Cluster {} is unavailable",
                         cluster.name
                     )))?;

--- a/load-balancer/src/service/auth.rs
+++ b/load-balancer/src/service/auth.rs
@@ -21,6 +21,13 @@ impl AuthService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -50,7 +57,7 @@ impl AuthService for Service {
                 },
                 Err(err) => {
                     tracing::warn!(
-                        "Error while getting curring user, user permissions could be partial: {:?}: {}",
+                        "Error while getting current user, user permissions could be partial: {:?}: {}",
                         err.code(),
                         err.message(),
                     );

--- a/load-balancer/src/service/health_check.rs
+++ b/load-balancer/src/service/health_check.rs
@@ -23,12 +23,13 @@ impl HealthChecksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)))?;
+
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/health_check.rs
+++ b/load-balancer/src/service/health_check.rs
@@ -28,8 +28,10 @@ impl HealthChecksService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)))?;
-
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )))?;
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/health_check.rs
+++ b/load-balancer/src/service/health_check.rs
@@ -23,6 +23,13 @@ impl HealthChecksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await

--- a/load-balancer/src/service/health_check.rs
+++ b/load-balancer/src/service/health_check.rs
@@ -28,7 +28,7 @@ impl HealthChecksService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!(
+                    Err(tonic::Status::unavailable(format!(
                         "Cluster {} is unavailable",
                         cluster.name
                     )))?;

--- a/load-balancer/src/service/mod.rs
+++ b/load-balancer/src/service/mod.rs
@@ -733,6 +733,7 @@ impl Service {
                 let mut client = match cluster.client(&Default::default()).await.map_err(IntoStatus::into_status) {
                     Ok(client) => client,
                     Err(err) => {
+                        cluster.available.store(false, std::sync::atomic::Ordering::Relaxed);
                         yield (cluster.clone(), Err(err));
                         return;
                     }
@@ -745,6 +746,7 @@ impl Service {
                 {
                     Ok(stream) => stream,
                     Err(err) => {
+                        cluster.available.store(false, std::sync::atomic::Ordering::Relaxed);
                         yield (cluster.clone(), Err(err));
                         return;
                     }
@@ -755,11 +757,13 @@ impl Service {
                     match response {
                         Ok(response) => yield (cluster.clone(), Result::<_, Status>::Ok(response)),
                         Err(err) => {
+                            cluster.available.store(false, std::sync::atomic::Ordering::Relaxed);
                             yield (cluster.clone(), Err(err));
                             return;
                         }
                     }
                 }
+                cluster.available.store(true, std::sync::atomic::Ordering::Relaxed);
             })
         });
 

--- a/load-balancer/src/service/mod.rs
+++ b/load-balancer/src/service/mod.rs
@@ -733,7 +733,7 @@ impl Service {
                 let mut client = match cluster.client(&Default::default()).await.map_err(IntoStatus::into_status) {
                     Ok(client) => client,
                     Err(err) => {
-                        cluster.available.store(false, std::sync::atomic::Ordering::Relaxed);
+                        cluster.set_available(false);
                         yield (cluster.clone(), Err(err));
                         return;
                     }
@@ -746,7 +746,7 @@ impl Service {
                 {
                     Ok(stream) => stream,
                     Err(err) => {
-                        cluster.available.store(false, std::sync::atomic::Ordering::Relaxed);
+                        cluster.set_available(false);
                         yield (cluster.clone(), Err(err));
                         return;
                     }
@@ -757,13 +757,16 @@ impl Service {
                     match response {
                         Ok(response) => yield (cluster.clone(), Result::<_, Status>::Ok(response)),
                         Err(err) => {
-                            cluster.available.store(false, std::sync::atomic::Ordering::Relaxed);
+                            cluster.set_available(false);
                             yield (cluster.clone(), Err(err));
                             return;
                         }
                     }
                 }
-                cluster.available.store(true, std::sync::atomic::Ordering::Relaxed);
+                // Recovery requires the full stream to complete without error.
+                // A partial or flaky stream leaves the cluster marked unavailable
+                // until the next successful update_sessions run.
+                cluster.set_available(true);
             })
         });
 

--- a/load-balancer/src/service/partitions.rs
+++ b/load-balancer/src/service/partitions.rs
@@ -33,6 +33,11 @@ impl PartitionsService for Service {
             let context =
                 RequestContext::new(context.headers().clone(), context.extensions().clone());
             Box::pin(async_stream::stream! {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!("Skipping cluster {} because it is marked as unavailable", cluster.name);
+                    Err(tonic::Status::unavailable("Cluster is unavailable"))?;
+                }
+
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -115,6 +120,14 @@ impl PartitionsService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
+
                 let mut client = cluster
                     .client(&context)
                     .await

--- a/load-balancer/src/service/partitions.rs
+++ b/load-balancer/src/service/partitions.rs
@@ -125,7 +125,10 @@ impl PartitionsService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
 
                 let mut client = cluster

--- a/load-balancer/src/service/partitions.rs
+++ b/load-balancer/src/service/partitions.rs
@@ -33,9 +33,9 @@ impl PartitionsService for Service {
             let context =
                 RequestContext::new(context.headers().clone(), context.extensions().clone());
             Box::pin(async_stream::stream! {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!("Skipping cluster {} because it is marked as unavailable", cluster.name);
-                    Err(tonic::Status::unavailable("Cluster is unavailable"))?;
+                    Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)))?;
                 }
 
                 let mut client = cluster
@@ -120,12 +120,12 @@ impl PartitionsService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
 
                 let mut client = cluster

--- a/load-balancer/src/service/results.rs
+++ b/load-balancer/src/service/results.rs
@@ -195,7 +195,10 @@ impl ResultsService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/results.rs
+++ b/load-balancer/src/service/results.rs
@@ -190,12 +190,12 @@ impl ResultsService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/results.rs
+++ b/load-balancer/src/service/results.rs
@@ -190,6 +190,13 @@ impl ResultsService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await

--- a/load-balancer/src/service/sessions.rs
+++ b/load-balancer/src/service/sessions.rs
@@ -309,7 +309,8 @@ impl SessionsService for Service {
 
         for cluster in self.clusters.values().cycle().skip(i % n).take(n) {
             if !cluster.is_available() {
-                err = tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name));
+                err =
+                    tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name));
                 continue;
             }
             match cluster.client(&context).await {

--- a/load-balancer/src/service/sessions.rs
+++ b/load-balancer/src/service/sessions.rs
@@ -308,7 +308,7 @@ impl SessionsService for Service {
         let mut err = None;
 
         for cluster in self.clusters.values().cycle().skip(i % n).take(n) {
-            if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+            if !cluster.is_available() {
                 continue;
             }
             match cluster.client(&context).await {

--- a/load-balancer/src/service/sessions.rs
+++ b/load-balancer/src/service/sessions.rs
@@ -305,10 +305,11 @@ impl SessionsService for Service {
             .counter
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        let mut err = None;
+        let mut err = tonic::Status::internal("No cluster");
 
         for cluster in self.clusters.values().cycle().skip(i % n).take(n) {
             if !cluster.is_available() {
+                err = tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name));
                 continue;
             }
             match cluster.client(&context).await {
@@ -344,17 +345,14 @@ impl SessionsService for Service {
                             .await?;
                             return Ok(response);
                         }
-                        Err(error) => err = Some(error.into_status()),
+                        Err(error) => err = error.into_status(),
                     }
                 }
-                Err(error) => err = Some(error.into_status()),
+                Err(error) => err = error.into_status(),
             }
         }
 
-        match err {
-            Some(err) => try_rpc!(bail err),
-            None => try_rpc!(bail tonic::Status::internal("No cluster")),
-        }
+        try_rpc!(bail err);
     }
 
     async fn pause(

--- a/load-balancer/src/service/sessions.rs
+++ b/load-balancer/src/service/sessions.rs
@@ -308,6 +308,9 @@ impl SessionsService for Service {
         let mut err = None;
 
         for cluster in self.clusters.values().cycle().skip(i % n).take(n) {
+            if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                continue;
+            }
             match cluster.client(&context).await {
                 Ok(mut client) => {
                     let span = client.span();

--- a/load-balancer/src/service/submitter.rs
+++ b/load-balancer/src/service/submitter.rs
@@ -35,6 +35,13 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -95,6 +102,9 @@ impl SubmitterService for Service {
         let mut err = None;
 
         for (_, cluster) in self.clusters.iter().cycle().skip(i % n).take(n) {
+            if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                continue;
+            }
             match cluster.client(&context).await {
                 Ok(mut client) => {
                     let span = client.span();
@@ -144,6 +154,13 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -193,6 +210,13 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -244,6 +268,13 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -316,6 +347,13 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -393,6 +431,13 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -443,6 +488,14 @@ impl SubmitterService for Service {
         let mut error = None;
 
         for cluster in self.clusters.values() {
+            if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    "Error while counting tasks, count could be partial: cluster {} is unavailable",
+                    cluster.name
+                );
+                error.get_or_insert(tonic::Status::unavailable("Cluster is unavailable"));
+                continue;
+            }
             let mut client = match cluster.client(&context).await {
                 Ok(client) => client,
                 Err(err) => {

--- a/load-balancer/src/service/submitter.rs
+++ b/load-balancer/src/service/submitter.rs
@@ -35,12 +35,12 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -102,7 +102,7 @@ impl SubmitterService for Service {
         let mut err = None;
 
         for (_, cluster) in self.clusters.iter().cycle().skip(i % n).take(n) {
-            if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+            if !cluster.is_available() {
                 continue;
             }
             match cluster.client(&context).await {
@@ -154,12 +154,12 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -210,12 +210,12 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -268,12 +268,12 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -347,12 +347,12 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -431,12 +431,12 @@ impl SubmitterService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -488,12 +488,12 @@ impl SubmitterService for Service {
         let mut error = None;
 
         for cluster in self.clusters.values() {
-            if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+            if !cluster.is_available() {
                 tracing::warn!(
                     "Error while counting tasks, count could be partial: cluster {} is unavailable",
                     cluster.name
                 );
-                error.get_or_insert(tonic::Status::unavailable("Cluster is unavailable"));
+                error.get_or_insert(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 continue;
             }
             let mut client = match cluster.client(&context).await {

--- a/load-balancer/src/service/submitter.rs
+++ b/load-balancer/src/service/submitter.rs
@@ -40,7 +40,10 @@ impl SubmitterService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -103,7 +106,8 @@ impl SubmitterService for Service {
 
         for (_, cluster) in self.clusters.iter().cycle().skip(i % n).take(n) {
             if !cluster.is_available() {
-                err = tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name));
+                err =
+                    tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name));
                 continue;
             }
             match cluster.client(&context).await {
@@ -157,7 +161,10 @@ impl SubmitterService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -213,7 +220,10 @@ impl SubmitterService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -271,7 +281,10 @@ impl SubmitterService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -350,7 +363,10 @@ impl SubmitterService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -434,7 +450,10 @@ impl SubmitterService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -491,7 +510,10 @@ impl SubmitterService for Service {
                     "Error while counting tasks, count could be partial: cluster {} is unavailable",
                     cluster.name
                 );
-                error.get_or_insert(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                error.get_or_insert(tonic::Status::unavailable(format!(
+                    "Cluster {} is unavailable",
+                    cluster.name
+                )));
                 continue;
             }
             let mut client = match cluster.client(&context).await {

--- a/load-balancer/src/service/submitter.rs
+++ b/load-balancer/src/service/submitter.rs
@@ -99,10 +99,11 @@ impl SubmitterService for Service {
             .counter
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        let mut err = None;
+        let mut err = tonic::Status::internal("No cluster");
 
         for (_, cluster) in self.clusters.iter().cycle().skip(i % n).take(n) {
             if !cluster.is_available() {
+                err = tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name));
                 continue;
             }
             match cluster.client(&context).await {
@@ -116,17 +117,14 @@ impl SubmitterService for Service {
 
                     match response {
                         Ok(response) => return Ok(response),
-                        Err(error) => err = Some(error.into_status()),
+                        Err(error) => err = error.into_status(),
                     }
                 }
-                Err(error) => err = Some(error.into_status()),
+                Err(error) => err = error.into_status(),
             }
         }
 
-        match err {
-            Some(err) => try_rpc!(bail err),
-            None => try_rpc!(bail tonic::Status::internal("No cluster")),
-        }
+        try_rpc!(bail err);
     }
 
     async fn cancel_session(

--- a/load-balancer/src/service/tasks.rs
+++ b/load-balancer/src/service/tasks.rs
@@ -182,7 +182,10 @@ impl TasksService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -238,7 +241,10 @@ impl TasksService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -296,7 +302,10 @@ impl TasksService for Service {
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
+                    return Err(tonic::Status::unavailable(format!(
+                        "Cluster {} is unavailable",
+                        cluster.name
+                    )));
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/tasks.rs
+++ b/load-balancer/src/service/tasks.rs
@@ -177,12 +177,12 @@ impl TasksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -233,12 +233,12 @@ impl TasksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)
@@ -291,12 +291,12 @@ impl TasksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
-                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                if !cluster.is_available() {
                     tracing::debug!(
                         "Skipping cluster {} because it is marked as unavailable",
                         cluster.name
                     );
-                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                    return Err(tonic::Status::unavailable(format!("Cluster {} is unavailable", cluster.name)));
                 }
                 let mut client = cluster
                     .client(&context)

--- a/load-balancer/src/service/tasks.rs
+++ b/load-balancer/src/service/tasks.rs
@@ -177,6 +177,13 @@ impl TasksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -226,6 +233,13 @@ impl TasksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await
@@ -277,6 +291,13 @@ impl TasksService for Service {
             .clusters
             .values()
             .map(|cluster| async {
+                if !cluster.available.load(std::sync::atomic::Ordering::Relaxed) {
+                    tracing::debug!(
+                        "Skipping cluster {} because it is marked as unavailable",
+                        cluster.name
+                    );
+                    return Err(tonic::Status::unavailable("Cluster is unavailable"));
+                }
                 let mut client = cluster
                     .client(&context)
                     .await


### PR DESCRIPTION
## Motivation

When a cluster becomes unreachable or starts returning errors, the load balancer would still attempt to forward requests to it on every call, incurring latency and propagating errors to clients. This change introduces lightweight availability tracking so that failing clusters are skipped immediately until they recover.

## Description

Adds an `AtomicBool available` field to the `Cluster` struct (initialized to `true`). In `service/mod.rs`, the streaming helper that fans out requests to clusters now sets `available = false` on any connection, stream, or response error, and resets it to `true` on clean stream completion.

All service handlers (applications, auth, health_check, partitions, results, sessions, submitter, tasks) check this flag before attempting to contact a cluster. If a cluster is marked unavailable, the request is skipped with a `tonic::Status::unavailable` error and a `DEBUG` log line.

Also fixes a minor typo in `auth.rs`: `"curring user"` → `"current user"`.

## Testing

No automated tests added — the load balancer lacks an integration test harness for multi-cluster failure scenarios. The logic is straightforward: a relaxed atomic load/store guards every cluster dispatch path.

## Impact

- Unavailable clusters are bypassed with no network round-trip, reducing tail latency during partial outages.
- The flag resets to `true` only after a successful full stream from `service/mod.rs`; other callers that hit an unavailable cluster receive `UNAVAILABLE` and must retry at a higher level.
- No configuration changes required; the field is internal to `Cluster`.

## Additional Information

The `Relaxed` memory ordering is intentional: the flag is a best-effort hint. There is no cross-thread data dependency on the boolean value itself, so stronger ordering is not necessary.