### PR TITLE
fix(sessions): remove unnecessary borrow in format string argument

### DIFF
--- a/load-balancer/src/service/sessions.rs
+++ b/load-balancer/src/service/sessions.rs
@@ -62,7 +62,7 @@ impl SessionsService for Service {
                         _ => {
                             try_rpc!(bail Status::invalid_argument(format!(
                                 "Condition {:?} is not valid for the field {}",
-                                &cond.condition, column.grpc
+                                cond.condition, column.grpc
                             )));
                         }
                     }


### PR DESCRIPTION
## Motivation

Clippy on nightly flagged an unnecessary borrow in a `format!` string argument.

## Description

Remove the `&` from `&cond.condition` in the `format!` call inside `SessionsService::list_sessions`. The value is passed to a `{:?}` debug formatter where the borrow is redundant.

## Testing

No tests added — this is a one-character lint fix with no behavioural change.

## Impact

None. The generated code is identical; this silences a nightly Clippy warning.

## Additional Information

Caught by `cargo clippy` on the nightly toolchain.